### PR TITLE
no need for sudo in .sources.sh

### DIFF
--- a/.sources.sh
+++ b/.sources.sh
@@ -1,10 +1,10 @@
-sudo echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel main restricted" > /etc/apt/sources.list
-sudo echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates main restricted" >> /etc/apt/sources.list
-sudo echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel universe" >> /etc/apt/sources.list
-sudo echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates universe" >> /etc/apt/sources.list
-sudo echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel multiverse" >> /etc/apt/sources.list
-sudo echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates multiverse" >> /etc/apt/sources.list
-sudo echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel-backports main restricted universe multiverse" >> /etc/apt/sources.list
-sudo echo "deb http://security.ubuntu.com/ubuntu devel-security main restricted" >> /etc/apt/sources.list
-sudo echo "deb http://security.ubuntu.com/ubuntu devel-security universe" >> /etc/apt/sources.list
-sudo echo "deb http://security.ubuntu.com/ubuntu devel-security multiverse" >> /etc/apt/sources.list 
+echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel main restricted" > /etc/apt/sources.list
+echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates main restricted" >> /etc/apt/sources.list
+echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel universe" >> /etc/apt/sources.list
+echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates universe" >> /etc/apt/sources.list
+echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel multiverse" >> /etc/apt/sources.list
+echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates multiverse" >> /etc/apt/sources.list
+echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel-backports main restricted universe multiverse" >> /etc/apt/sources.list
+echo "deb http://security.ubuntu.com/ubuntu devel-security main restricted" >> /etc/apt/sources.list
+echo "deb http://security.ubuntu.com/ubuntu devel-security universe" >> /etc/apt/sources.list
+echo "deb http://security.ubuntu.com/ubuntu devel-security multiverse" >> /etc/apt/sources.list 


### PR DESCRIPTION
Hi,

since we're calling .sources.sh via "rhino-init" with sudo rights ("sudo bash ~/.sources.sh") there is no need for sudo infront of every echo command in the script.

Cheers!