### PR TITLE
Detect Locale When adding sources.list

### DIFF
--- a/.sources.sh
+++ b/.sources.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 countryCode=$(locale | awk -F"[_.]" '/LANG/{print tolower($2)}')
 
-cat >> /etc/apt/sources.list << REPOS
+cat > /etc/apt/sources.list << REPOS
 deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel main restricted
 deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel-updates main restricted
 deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel universe

--- a/.sources.sh
+++ b/.sources.sh
@@ -1,12 +1,14 @@
-echo "deb http://gb.archive.ubuntu.com/ubuntu/ devel main restricted" > /etc/apt/sources.list
+#!/usr/bin/env bash
+countryCode=$(locale | awk -F"[_.]" '/LANG/{print tolower($2)}')
 
 cat >> /etc/apt/sources.list << REPOS
-deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates main restricted
-deb http://gb.archive.ubuntu.com/ubuntu/ devel universe
-deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates universe
-deb http://gb.archive.ubuntu.com/ubuntu/ devel multiverse
-deb http://gb.archive.ubuntu.com/ubuntu/ devel-updates multiverse
-deb http://gb.archive.ubuntu.com/ubuntu/ devel-backports main restricted universe multiverse
+deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel main restricted
+deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel-updates main restricted
+deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel universe
+deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel-updates universe
+deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel multiverse
+deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel-updates multiverse
+deb http://$countryCode.archive.ubuntu.com/ubuntu/ devel-backports main restricted universe multiverse
 deb http://security.ubuntu.com/ubuntu devel-security main restricted
 deb http://security.ubuntu.com/ubuntu devel-security universe
 deb http://security.ubuntu.com/ubuntu devel-security multiverse


### PR DESCRIPTION
This improves rhino-update because the mirrors were hardcoded to gb.archive.ubuntu.com, and I noticed updates were slow in the US. 

Originally, I thought it would be a good idea to just use archive.ubuntu.com, but realized in the Ubuntu wiki, there is an official mirror per country code (https://wiki.ubuntu.com/Mirrors)

I loosely based this change off of a fairly decent tutorial here: https://linuxconfig.org/how-to-select-the-fastest-apt-mirror-on-ubuntu-linux. It discusses using a program called netselect, which would autodetect the best mirror, but I couldn't install it with apt, plus it didn't work when I compiled it, and hasn't been touched since 2010). So we'll try this for now. 

If this cases any issues, we can just default to archive.ubuntu,com (Canonical should load balance this or use a CDN, but I can't confirm if they actually do that)

I am detecting the country code by parsing locale, as described here: https://askubuntu.com/questions/350679/get-system-locale-language-code-in-bash-for-a-dynamic-path#comment2274673_350689

I tested this detection in Ubuntu and RRR, and it worked for me, but please test it before the release. Note: it does not work in Ubuntu LTS via WSL, but that doesn't matter